### PR TITLE
Bump to Lua53

### DIFF
--- a/src/lua-hiredis.c
+++ b/src/lua-hiredis.c
@@ -461,7 +461,7 @@ static int lhiredis_connect(lua_State * L)
   }
   else
   {
-    pContext = redisConnect(host_or_socket, luaL_checkinteger(L, 2));
+    pContext = redisConnect(host_or_socket, (int)luaL_checkinteger(L, 2));
   }
 
   if (!pContext)

--- a/src/lua-hiredis.c
+++ b/src/lua-hiredis.c
@@ -461,7 +461,7 @@ static int lhiredis_connect(lua_State * L)
   }
   else
   {
-    pContext = redisConnect(host_or_socket, luaL_checkint(L, 2));
+    pContext = redisConnect(host_or_socket, luaL_checkinteger(L, 2));
   }
 
   if (!pContext)

--- a/test/test.lua
+++ b/test/test.lua
@@ -155,7 +155,7 @@ do
     a[#a + 1] = "SET"
   end
   -- Too many arguments
-  assert(pcall(conn.command, conn, unpack(a)) == false)
+  assert(pcall(conn.command, conn, table.unpack(a)) == false)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Add the changes required to use `lua-hiredis` with `Lua5.3`.
The changes added are compliant with: `Lua51` and also `Lua52`.

Tested on my end. All unit tests pass. Also tested in a private project, so far, so good.

@agladysh, When you have some free time, please take a look.

Thanks 